### PR TITLE
Add missing convar flag

### DIFF
--- a/Provoxin.RGB/mod.json
+++ b/Provoxin.RGB/mod.json
@@ -29,7 +29,8 @@
 		},
 		{
 			"Name": "rgb_enemy_color",
-			"DefaultValue": "0.8 0.25 0.15"
+			"DefaultValue": "0.8 0.25 0.15",
+			"Flags": 16777216
 		},
 		{
 			"Name": "rgb_ally_rainbow",  // whether allies will cycle through colors


### PR DESCRIPTION
In #2 , the convar flag `16777216` for `rgb_enemy_color` was missing and it wasn't caught when reviewing the PR. 